### PR TITLE
Add deepId feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Common options
   --inline, -i  If you want to embed the sprite into your HTML source, you will want to set this to true in order to prevent the creation of SVG namespace declarations and to set some other attributes for effectively hiding the library sprite.
   --iconPrefix, -p  The name prefix for each icon.
   --iconSuffix, -s  The name suffix for each icon.
+  --deepId, -e  id of an icon is the path to that icon from <source-directory>.
 
 Clean options
   --stripEmptyTags  Removes empty tags such as "defs" or "g".

--- a/fixtures/depth/not-too/long/circle.svg
+++ b/fixtures/depth/not-too/long/circle.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: My hands -- version 2.0.0 -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128" sketch:type="sketch">
+
+	<style><![CDATA[
+		.circle {
+			fill: #f2f2f2;
+			stroke: #ddd;
+			stroke-width: 4px;
+		}
+	]]></style>
+
+	<title>Title</title>
+	<desc>Description</desc>
+
+	<g>
+		<circle class="circle" cx="64" cy="64" r="60"></circle>
+		<rect x="24" y="24" width="80" height="80" fill="#ccc"></rect>
+		<rect x="32" y="32" width="64" height="64" style="fill: #ddd; stroke-width: 2px; stroke: #f2f2f2;"></rect>
+	</g>
+
+</svg>

--- a/fixtures/sprite.svg
+++ b/fixtures/sprite.svg
@@ -1,6 +1,14 @@
 <svg width="0" height="0" position="absolute">
-
 	<symbol id="circle" viewBox="0 0 128 128">
+		<style><![CDATA[.circle {fill: #f2f2f2;stroke: #ddd;stroke-width: 4px;}]]></style>
+		<g>
+			<circle class="circle" cx="64" cy="64" r="60"></circle>
+			<rect x="24" y="24" width="80" height="80" fill="#ccc"></rect>
+			<rect x="32" y="32" width="64" height="64" style="fill: #ddd; stroke-width: 2px; stroke: #f2f2f2;"></rect>
+		</g>
+	</symbol>
+
+	<symbol id="depth/not-too/long/circle" viewBox="0 0 128 128">
 		<style><![CDATA[.circle {fill: #f2f2f2;stroke: #ddd;stroke-width: 4px;}]]></style>
 		<g>
 			<circle class="circle" cx="64" cy="64" r="60"></circle>
@@ -17,5 +25,4 @@
 			<rect x="32" y="32" width="64" height="64" style="fill: #ddd; stroke-width: 2px; stroke: #f2f2f2;"></rect>
 		</g>
 	</symbol>
-
 </svg>

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -15,6 +15,7 @@ describe('CLI', () => {
 			'.tmp/sprite.svg',
 			'--ignore=sprite.svg',
 			'--inline',
+			'--deepId',
 			'--stripExtraAttrs',
 			'--stripTags=title',
 			'--stripTags=desc',
@@ -22,7 +23,7 @@ describe('CLI', () => {
 			'--stripEmptyTags=g'
 		]).stdout;
 
-		assert.ok(stdout.indexOf('Created 1 SVG sprite from 2 SVG\'s.') !== -1);
+		assert.ok(stdout.indexOf('Created 1 SVG sprite from 3 SVG\'s.') !== -1);
 
 		const sprite = fs.readFileSync('.tmp/sprite.svg', 'utf-8');
 		assert.equal(sprite, svg.replace(/[\r\n\t]|\s{2,}/g, ''));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ const cli = <any>meow(`
 		--inline, -i  If you want to embed the sprite into your HTML source, you will want to set this to true in order to prevent the creation of SVG namespace declarations and to set some other attributes for effectively hiding the library sprite.
 		--iconPrefix, -p  The name prefix for each icon.
 		--iconSuffix, -s  The name suffix for each icon.
+		--deepId, -e  id of an icon is the path to that icon from <source-directory>.
 
 	Clean options
 		--stripEmptyTags  Removes empty tags such as "defs" or "g".
@@ -43,7 +44,8 @@ const cli = <any>meow(`
 		d: 'ignore',
 		i: 'inline',
 		p: 'iconPrefix',
-		s: 'iconSuffix'
+		s: 'iconSuffix',
+		e: 'deepId'
 	}
 });
 
@@ -82,9 +84,9 @@ log('Created spriter instance');
 readdirP(cli.input[0], cli.flags.ignore).then((files) => {
 	log('Read directory...');
 
-	files = files.map((filename) => {
+	files = files.sort().map((filename) => {
 		return readFileP(filename, 'utf-8').then((content) => {
-			const name = path.basename(filename, '.svg');
+			const name = cli.flags.deepId ? path.relative(cli.input[0], filename).replace(/\.svg$/, '') : path.basename(filename, '.svg');
 			sprite.add(name, content);
 			stats++;
 		});


### PR DESCRIPTION
The `deepId` can be useful in some cases.
For example, If your assets are organize like describe below :

```
application
|-src
|- assets
    |-products
       |- product-1-id
           |- brand.svg
           |- ...
       |- product-2-id
           |- brand.svg
           |- ...
       ...
       |- product-n-id
           |- brand.svg
           |- ...
```

To display your products, you will like to write an angular `*ngFor` loop which would look like this :
```html
<div *ngFor="let product of products">
  <svg-icon-loader [icon]="'products/' + product.id + '/brand'"></svg-icon-loader>
</div>
```
